### PR TITLE
Change Docker Hub Repo name

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,20 +16,20 @@ dependencies:
     - docker cp packer:/usr/local/bin/ pkr_files
     - docker cp terraform:/usr/local/bin/ tf_files
     - if [[ -e ~/docker/image.tar ]]; then docker load --input ~/docker/image.tar; fi
-    - docker build -t whistlelabs/ci .
-    - mkdir -p ~/docker; docker save whistlelabs/ci > ~/docker/image.tar
+    - docker build -t whistle/ci .
+    - mkdir -p ~/docker; docker save whistle/ci > ~/docker/image.tar
 
 test:
   override:
-    - docker run --entrypoint /bin/sh whistlelabs/ci -c "gem list | grep covalence"
-    - docker run --entrypoint /bin/sh whistlelabs/ci -c "aws --version"
-    - docker run --entrypoint /bin/sh whistlelabs/ci -c "packer version"
-    - docker run --entrypoint /bin/sh whistlelabs/ci -c "terraform version"
+    - docker run --entrypoint /bin/sh whistle/ci -c "gem list | grep covalence"
+    - docker run --entrypoint /bin/sh whistle/ci -c "aws --version"
+    - docker run --entrypoint /bin/sh whistle/ci -c "packer version"
+    - docker run --entrypoint /bin/sh whistle/ci -c "terraform version"
 
 deployment:
   hub:
     branch: master
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - docker tag -f `docker images | grep -E 'whistlelabs/ci' | awk '{print $3}'` whistlelabs/ci:${PACKER_VERSION_TAG}.${TERRAFORM_VERSION_TAG}.${CIRCLE_BUILD_NUM}
-      - docker push whistlelabs/ci
+      - docker tag -f `docker images | grep -E 'whistle/ci' | awk '{print $3}'` whistle/ci:${PACKER_VERSION_TAG}.${TERRAFORM_VERSION_TAG}.${CIRCLE_BUILD_NUM}
+      - docker push whistle/ci


### PR DESCRIPTION
Originally used Whistlelabs for repo organization.  See others in account use whistle, so change to that to be consistent.

Docker container will be whistle/ci.