### PR TITLE
DEVOPS-1289 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 pkr_files/**
 tf_files/**
+node_files.tar.gz
+node_files

--- a/Dockerfile-build-node
+++ b/Dockerfile-build-node
@@ -1,6 +1,8 @@
 FROM unifio/covalence:latest
 MAINTAINER "WhistleLabs, Inc. <devops@whistle.com>"
 
+LABEL node_version="7.5.0"
+
 ENV VERSION=v7.5.0 NPM_VERSION=4
 #ENV CONFIG_FLAGS="--fully-static --without-npm" DEL_PKGS="libstdc++" RM_DIRS=/usr/include
 

--- a/Dockerfile-build-node
+++ b/Dockerfile-build-node
@@ -1,0 +1,58 @@
+FROM unifio/covalence:latest
+MAINTAINER "WhistleLabs, Inc. <devops@whistle.com>"
+
+ENV VERSION=v7.5.0 NPM_VERSION=4
+#ENV CONFIG_FLAGS="--fully-static --without-npm" DEL_PKGS="libstdc++" RM_DIRS=/usr/include
+
+RUN mkdir -p /tmp/build && \
+    cd /tmp/build && \
+
+    # Install glibc
+    wget -q -O /etc/apk/keys/sgerrand.rsa.pub "https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub" && \
+    wget -q "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk" && \
+    apk add glibc-2.23-r3.apk && \
+
+    # Install PIP
+    apk add --no-cache --update curl zip curl-dev jq python-dev && \
+    curl -O https://bootstrap.pypa.io/get-pip.py && \
+    python get-pip.py && \
+
+    # Install AWS CLI
+    pip install awscli && \
+
+    # Install Misc. Ruby tools
+    gem install awesome_print consul_loader thor --no-ri --no-rdoc && \
+    # Install Node
+    cd / && \
+    apk add --no-cache make gcc g++ linux-headers binutils-gold libstdc++ && \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 && \
+    curl -sSLO https://nodejs.org/dist/${VERSION}/node-${VERSION}.tar.xz && \
+    curl -sSL https://nodejs.org/dist/${VERSION}/SHASUMS256.txt.asc | gpg --batch --decrypt | \
+      grep " node-${VERSION}.tar.xz\$" | sha256sum -c | grep . && \
+    tar -xf node-${VERSION}.tar.xz && \
+    cd node-${VERSION} && \
+    ./configure --prefix=/usr ${CONFIG_FLAGS} && \
+    make -j$(getconf _NPROCESSORS_ONLN) && \
+    make install && \
+    cd / && \
+    if [ -x /usr/bin/npm ]; then \
+      npm install -g npm@${NPM_VERSION} && \
+      find /usr/lib/node_modules/npm -name test -o -name .bin -type d | xargs rm -rf; \
+    fi && \
+    apk del make gcc g++ linux-headers binutils-gold ${DEL_PKGS} && \
+    rm -rf ${RM_DIRS} /node-${VERSION}* /usr/share/man /tmp/* /var/cache/apk/* \
+      /root/.npm /root/.node-gyp /root/.gnupg /usr/lib/node_modules/npm/man \
+      /usr/lib/node_modules/npm/doc /usr/lib/node_modules/npm/html /usr/lib/node_modules/npm/scripts \
+
+    # Other Cleanup
+    cd /tmp && \
+    rm -rf /tmp/build && \
+    mkdir -p /tmp && chmod a+rwx /tmp

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,0 +1,33 @@
+FROM unifio/covalence:latest
+MAINTAINER "WhistleLabs, Inc. <devops@whistle.com>"
+
+LABEL packer_version="0.12.0"
+LABEL terraform_version="0.8.8"
+LABEL node_version="7.5.0"
+
+RUN mkdir -p /tmp/build && \
+    cd /tmp/build && \
+
+    # Install glibc
+    wget -q -O /etc/apk/keys/sgerrand.rsa.pub "https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub" && \
+    wget -q "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk" && \
+    apk add glibc-2.23-r3.apk && \
+
+    # Install PIP
+    apk add --no-cache --update curl curl-dev jq python-dev && \
+    curl -O https://bootstrap.pypa.io/get-pip.py && \
+    python get-pip.py && \
+
+    # Install AWS CLI
+    pip install awscli && \
+
+    # Install Misc. Ruby tools
+    gem install awesome_print consul_loader thor --no-ri --no-rdoc && \
+
+    # Cleanup
+    cd /tmp && \
+    rm -rf /tmp/build
+
+COPY pkr_files/packer* /usr/local/bin/
+COPY tf_files/terraform* /usr/local/bin/
+ADD node_files.tar.gz /

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    MAJOR_VERSION_TAG: 1
+    MAJOR_VERSION_TAG: 2
     PACKER_VERSION_TAG: 0.12.0
     TERRAFORM_VERSION_TAG: 0.8.8
     NODE_VERSION_TAG: 7.5.0
@@ -15,7 +15,7 @@ machine:
 
 dependencies:
   pre:
-    - sudo apt-get install jq
+    - sudo apt-get update; sudo apt-get install -y jq curl
   cache_directories:
     - "~/docker"
   override:
@@ -25,7 +25,16 @@ dependencies:
       if [[ $(./tagexists.sh ${CI_IMAGE_NAME}) == "1" ]];then
         ./copybins.sh node && \
         echo node >> ~/.allbinaries && echo npm >> ~/.allbinaries
-      fi
+      else
+        echo "Building Node.js binary image. ${CI_NODE_IMAGE_NAME} was not found."
+        echo "The build will take about 40 minutes to complete."
+          if docker build -f Dockerfile-build-node --rm=false -t "${CI_NODE_IMAGE_NAME}" .; then
+            echo newJStag >> ~/.allbinaries
+            echo "${CI_NODE_IMAGE_NAME} has been built and will be pushed to dockerhhub"
+            ./copybins.sh node && \
+            echo node >> ~/.allbinaries && echo npm >> ~/.allbinaries
+          fi
+        fi
     - >
       if [[ $(DOCKER_BIN_TAG="${TERRAFORM_VERSION_TAG}" ./tagexists.sh ${TF_IMAGE}) == "1" ]];then
         ./copybins.sh terraform && \
@@ -64,6 +73,11 @@ test:
           --entrypoint /bin/sh "${CI_IMAGE_NAME}" -c "terraform version"
       fi
     - >
+      if grep -q newJStag ~/.allbinaries; then
+        echo "The ${CI_NODE_IMAGE_NAME} was built but still needs to be pushed to docker hub."
+        docker run --entrypoint /bin/sh "${CI_IMAGE_NAME}:${DOCKER_BIN_TAG}" -c "node --version"
+      fi
+    - >
       if grep -q node ~/.allbinaries; then
         docker run --entrypoint /bin/sh "${CI_IMAGE_NAME}" -c "node --version"
       fi
@@ -82,8 +96,15 @@ deployment:
         if grep -q node ~/.allbinaries; then
           docker tag "${IMAGE_TO_TAG}" \
           "${CI_IMAGE_NAME}":${PACKER_VERSION_TAG}.${TERRAFORM_VERSION_TAG}.${NODE_VERSION_TAG}.${CIRCLE_BUILD_NUM}
-        else
-          docker tag "${IMAGE_TO_TAG}" \
-          "${CI_IMAGE_NAME}":${PACKER_VERSION_TAG}.${TERRAFORM_VERSION_TAG}.${CIRCLE_BUILD_NUM}
-        fi
+          if grep -q newJStag ~/.allbinaries; then
+            IMAGE_TO_TAG=$(docker images | grep -E "${DOCKER_BIN_TAG}" | awk '{print $3}')
+            docker tag "${IMAGE_TO_TAG}" \
+           ${CI_IMAGE_NAME}:${DOCKER_BIN_TAG}.${CIRCLE_BUILD_NUM} && \
+            docker push "${CI_IMAGE_NAME}":${DOCKER_BIN_TAG}.${CIRCLE_BUILD_NUM} && \
+            docker push "${CI_IMAGE_NAME}":${DOCKER_BIN_TAG}
+          fi
+         else
+           docker tag "${IMAGE_TO_TAG}" \
+            "${CI_IMAGE_NAME}":${PACKER_VERSION_TAG}.${TERRAFORM_VERSION_TAG}.${CIRCLE_BUILD_NUM}
+         fi
       - docker push "${CI_IMAGE_NAME}"

--- a/circle.yml
+++ b/circle.yml
@@ -3,33 +3,87 @@ machine:
     MAJOR_VERSION_TAG: 1
     PACKER_VERSION_TAG: 0.12.0
     TERRAFORM_VERSION_TAG: 0.8.8
+    NODE_VERSION_TAG: 7.5.0
+    DOCKER_BIN_TAG: 'node-7.5.0'
+    CI_CONTAINER_NAME: 'whistle-ci'
+    TF_IMAGE: 'unifio/terraform'
+    PKR_IMAGE: 'unifio/packer'
+    CI_IMAGE_NAME: 'whistle/ci'
+    CI_NODE_IMAGE_NAME: 'whistle/ci:node-7.5.0'
   services:
     - docker
 
 dependencies:
+  pre:
+    - sudo apt-get install jq
   cache_directories:
     - "~/docker"
   override:
     - docker info
-    - docker run --name packer unifio/packer:${PACKER_VERSION_TAG} version
-    - docker run --name terraform unifio/terraform:${TERRAFORM_VERSION_TAG} version
-    - docker cp packer:/usr/local/bin/ pkr_files
-    - docker cp terraform:/usr/local/bin/ tf_files
-    - if [[ -e ~/docker/image.tar ]]; then docker load --input ~/docker/image.tar; fi
-    - docker build -t whistle/ci .
-    - mkdir -p ~/docker; docker save whistle/ci > ~/docker/image.tar
+    - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+    - >
+      if [[ $(./tagexists.sh ${CI_IMAGE_NAME}) == "1" ]];then
+        ./copybins.sh node && \
+        echo node >> ~/.allbinaries && echo npm >> ~/.allbinaries
+      fi
+    - >
+      if [[ $(DOCKER_BIN_TAG="${TERRAFORM_VERSION_TAG}" ./tagexists.sh ${TF_IMAGE}) == "1" ]];then
+        ./copybins.sh terraform && \
+        echo terraform >> ~/.allbinaries
+      fi
+    - >
+      if [[ $(DOCKER_BIN_TAG="${PACKER_VERSION_TAG}" ./tagexists.sh ${PKR_IMAGE}) == "1" ]];then
+        ./copybins.sh packer && \
+        echo packer >> ~/.allbinaries
+      fi
+    - >
+      if [[ -e ~/docker/image.tar ]]; then
+        docker load --input ~/docker/image.tar
+      fi
+    - >
+      if grep -q node ~/.allbinaries; then
+        docker build -f Dockerfile-node --rm=false -t "${CI_IMAGE_NAME}" .
+      else
+        docker build --rm=false -t "${CI_IMAGE_NAME}" .
+      fi
+    - mkdir -p ~/docker; docker save "${CI_IMAGE_NAME}" > ~/docker/image.tar
+    - cat ~/.allbinaries
 
 test:
   override:
-    - docker run --entrypoint /bin/sh whistle/ci -c "gem list | grep covalence"
-    - docker run --entrypoint /bin/sh whistle/ci -c "aws --version"
-    - docker run --entrypoint /bin/sh whistle/ci -c "packer version"
-    - docker run --entrypoint /bin/sh whistle/ci -c "terraform version"
-
+    - docker run --entrypoint /bin/sh "${CI_IMAGE_NAME}" -c "gem list | grep covalence"
+    - docker run --entrypoint /bin/sh "${CI_IMAGE_NAME}" -c "aws --version"
+    - >
+      if grep -q packer ~/.allbinaries; then
+        docker run -e CHECKPOINT_DISABLE=1 \
+          --entrypoint /bin/sh "${CI_IMAGE_NAME}" -c "packer version"
+      fi
+    - >
+      if grep -q terraform ~/.allbinaries; then
+        docker run -e CHECKPOINT_DISABLE=1 \
+          --entrypoint /bin/sh "${CI_IMAGE_NAME}" -c "terraform version"
+      fi
+    - >
+      if grep -q node ~/.allbinaries; then
+        docker run --entrypoint /bin/sh "${CI_IMAGE_NAME}" -c "node --version"
+      fi
+    - >
+      if grep -q npm ~/.allbinaries; then
+        docker run --entrypoint /bin/sh "${CI_IMAGE_NAME}" -c "npm --version"
+      fi
+    - cat ~/.allbinaries
 deployment:
   hub:
     branch: master
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - docker tag -f `docker images | grep -E 'whistle/ci' | awk '{print $3}'` whistle/ci:${PACKER_VERSION_TAG}.${TERRAFORM_VERSION_TAG}.${CIRCLE_BUILD_NUM}
-      - docker push whistle/ci
+      - >
+        IMAGE_TO_TAG=$(docker images | grep -E "${CI_IMAGE_NAME}" | grep -v "${DOCKER_BIN_TAG}" | awk '{print $3}')
+        if grep -q node ~/.allbinaries; then
+          docker tag "${IMAGE_TO_TAG}" \
+          "${CI_IMAGE_NAME}":${PACKER_VERSION_TAG}.${TERRAFORM_VERSION_TAG}.${NODE_VERSION_TAG}.${CIRCLE_BUILD_NUM}
+        else
+          docker tag "${IMAGE_TO_TAG}" \
+          "${CI_IMAGE_NAME}":${PACKER_VERSION_TAG}.${TERRAFORM_VERSION_TAG}.${CIRCLE_BUILD_NUM}
+        fi
+      - docker push "${CI_IMAGE_NAME}"

--- a/copybins.sh
+++ b/copybins.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+platform=''
+tarOpt=''
+tarArgs=''
+ciScriptDebug=${CI_SCRIPT_DEBUG:-""}
+unamestr=$(uname)
+tf_version=${TERRAFORM_VERSION_TAG:-""}
+pkr_version=${PACKER_VERSION_TAG:-""}
+tf_image=${TF_IMAGE:-'unifio/terraform'}
+pkr_image=${pkr_image:-'unifio/packer'}
+binaryToInstall=${1:-""}
+if [[ ${binaryToInstall} ]]; then
+
+  if [[ "$unamestr" == 'Linux' ]]; then
+    platform='linux'
+    tarOpt=''
+    tarArgs="--wildcards --exclude=*zipinfo*"
+  elif [[ "$unamestr" == 'Darwin' || "$unamestr" == 'FreeBSD' ]]; then
+    platform='freebsd'
+    tarOpt=''
+    tarArgs=''
+  fi
+  if [[ $ciScriptDebug ]];then
+    theArgs="-v $theArgs"
+  fi
+
+  read -r -d '' fileList << EOM
+  ${tarOpt} /usr/bin/unzip        \
+  ${tarOpt} /usr/include/node     \
+  ${tarOpt} /usr/lib/node_modules \
+  ${tarOpt} /usr/share/doc        \
+  ${tarOpt} /usr/share/systemtap  \
+  ${tarOpt} /usr/bin/node         \
+  ${tarOpt} /usr/bin/npm          \
+  ${tarOpt} /usr/bin/zip
+EOM
+  # Set Default values or check for environment variable override
+  destDir=${CI_DEST_DIR:-"node_files"}
+  containerName=${CI_CONTAINER_NAME:-"whistle-ci"}
+  imageName=${CI_NODE_IMAGE_NAME:-"whistle/ci:node-7.5.0"}
+  containerSuffix=${CI_CONTAINER_SUFFIX:-""}
+  binaryFile=${CI_BINARY_FILE:-"node"}
+
+  # If the node container
+  if [[ "${binaryToInstall}" == "${binaryFile}" ]];then
+    containerName="whistle-ci_${binaryFile}"
+    # Run the node container, name it, and get binary version number.
+    docker run --entrypoint "${binaryFile}" --name "${containerName}${containerSuffix}" \
+            "${imageName}" --version 2>/dev/null
+    # now verify that the container ran and echo its ID for reference
+    matchingStarted=$(docker ps -lqa --filter="name=${containerName}${containerSuffix}" \
+                  --format="{{.Names}},{{.ID}},{{.Image}},{{.Command}}")
+    echo "Last container ran matching ${matchingStarted}"
+
+    if [[ $matchingStarted ]]; then
+      mkdir -p "${destDir}"
+      docker cp "${containerName}${containerSuffix}":/ - | (cd "${destDir}" && tar -xp $tarArgs $fileList)
+      tar czvf ./"${destDir}".tar.gz -C "${destDir}"/ usr/
+      if tar tvzf ./"${destDir}".tar.gz | grep -q "\/bin\/${binaryFile}\$"; then
+        echo "$binaryFile found in tarball ready for copy to container"
+      else
+        exit 1
+      fi
+    fi
+  fi
+
+  # now take care of the terraform files.
+  if [[ $tf_version && $tf_image && "${binaryToInstall}" == "terraform" ]]; then
+    echo "Running the ${binaryToInstall} container and naming it if it hasn't been already."
+    containerName=terraform
+    docker run --name "${containerName}" "${tf_image}":"${tf_version}" version 2>/dev/null
+    # veirfy that the container ran and grab its ID
+    matchingStarted=$(docker ps -lqa --filter="name=${containerName}${containerSuffix}" \
+                --format="{{.Names}},{{.ID}},{{.Image}},{{.Command}}")
+    echo "Terraform container ran ${matchingStarted}"
+    if [[ $matchingStarted ]];then
+      echo "Copying binaries.."
+      docker cp ${containerName}:/usr/local/bin/ tf_files
+    fi
+  fi
+  # now take care of the packer files
+  if [[ $pkr_version && $pkr_image && "${binaryToInstall}" == "packer" ]]; then
+    echo "Running the packer container and naming it if it hasn't been already."
+    containerName=packer
+    docker run --name "${containerName}" "${pkr_image}":"${pkr_version}" version 2>/dev/null
+    # veirfy that the container ran and grab its ID
+    matchingStarted=$(docker ps -lqa --filter="name=${containerName}${containerSuffix}" \
+                --format="{{.Names}},{{.ID}},{{.Image}},{{.Command}}")
+    echo "packer container ran ${matchingStarted}"
+    if [[ $matchingStarted ]];then
+      echo "Copying binaries.."
+      docker cp ${containerName}:/usr/local/bin/ pkr_files
+    fi
+  fi
+else
+  echo "No binary type specified for copy"
+  exit 1
+fi

--- a/tagexists.sh
+++ b/tagexists.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+dockerRepo=${DOCKER_REPO:-$1}
+dockerRegistry=${DOCKER_REGISTRY:-docker.io}
+jsonParser=$(which jq)
+tagWanted=${DOCKER_BIN_TAG:-"node-2.0.0"}
+#
+#  Docker funcs
+#
+dkrRelativeRepoName() {
+  # given $dockerRegistry/repo/path:tag, return the repo/path
+  set +o pipefail
+  echo ${1-} | sed -e "s|^$dockerRegistry/||" | cut -d: -f1
+}
+
+dkrSortVersions() {
+  # read stdin, sort by version number descending, and write stdout
+  # assumes X.Y.Z version numbers
+
+  # this will sort tags like pr-3001, pr-3002 to the END of the list
+  # and tags like 2.1.4 BEFORE 2.1.4-gitsha
+
+  sort -s -t- -k 2,2nr |  sort -t. -s -k 1,1nr -k 2,2nr -k 3,3nr -k 4,4nr
+}
+
+dkrBasicAuth() {
+  #
+  # read basic auth credentials from `docker login`
+  #
+  cat "${HOME}"/.docker/config.json | ${jsonParser} -r '.auths["https://index.docker.io/v1/"].auth'
+}
+
+
+dkrRegistryTagsList() {
+  # return a list of available tags for the given repository sorted
+  # by version number, descending
+  #
+  # Get tags list from dockerhub using v2 api and an auth.docker token
+  local rel_repository
+  local TOKEN
+  local allTags
+  rel_repository=$(dkrRelativeRepoName "${1}")
+  [ -z "$rel_repository" ] && return
+  TOKEN=$(curl -s -H "Authorization: Basic $(dkrBasicAuth)" \
+                  -H 'Accept: application/json' \
+                  "https://auth.docker.io/token?service=registry.docker.io&scope=repository:$rel_repository:pull" | ${jsonParser} -r .token)
+  allTags=$(curl -s -H "Authorization: Bearer $TOKEN" -H "Accept: application/json" \
+          "https://index.docker.io/v2/$rel_repository/tags/list" |
+          ${jsonParser} -cS '.tags? | .[]?')
+  echo "$allTags"
+}
+
+
+matchingTag=$(dkrRegistryTagsList "$dockerRepo" | grep -o \""${tagWanted}"\" | sed 's/"//g')
+if [ "${matchingTag}" ]; then
+  echo 1
+else
+  echo 0
+fi


### PR DESCRIPTION
- Created a script for copying just the node binaries from a special tagged version node-7.5.0 that will be created in the whistle docker hub. copybins.sh
- Created a script for testing whether or not a tag is present in a docker repository. Allows for building a version without the tag if the tag isn’t present. Can later additionally add to build the tag if the tag isn’t present then leverage the the tag later. tagexists.sh
- Added logic to check whether or not a certain binary is being installed or not in the circle.yaml.
- Added node version information to the tagging so that if a node ci tool is generated the Node version tag is included in addition to the terraform and packer tags.
*NOTE: Building the node tag takes over 30 minutes in circleci which is why it isn't added to the standard build process and a separate tag is used to copy the binaries from.