### PR TITLE
DEVOPS-1446: new covalence and new terraform point release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM unifio/covalence:latest
 MAINTAINER "WhistleLabs, Inc. <devops@whistle.com>"
 
 LABEL packer_version="1.0.0"
-LABEL terraform_version="0.9.6"
+LABEL terraform_version="0.9.8"
 
 RUN mkdir -p /tmp/build && \
     cd /tmp/build && \

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   environment:
     MAJOR_VERSION_TAG: 2
     PACKER_VERSION_TAG: 1.0.0
-    TERRAFORM_VERSION_TAG: 0.9.6
+    TERRAFORM_VERSION_TAG: 0.9.8
     NODE_VERSION_TAG: 7.5.0
     DOCKER_BIN_TAG: 'node-7.5.0'
     CI_CONTAINER_NAME: 'whistle-ci'


### PR DESCRIPTION
Let's get this rolled out before we start the AMI upgrade as well.