### PR TITLE
Add new version of aws provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN mkdir -p /usr/local/bin/terraform-providers && \
     aws:0.1.4 \
     aws:1.10.0 \
     aws:1.18.0 \
+    aws:1.33.0 \
     consul:0.1.0 \
     datadog:0.1.1 \
     github:0.1.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN mkdir -p /usr/local/bin/terraform-providers && \
     google:0.1.3 \
     heroku:0.1.0 \
     logentries:0.1.0 \
-    newrelic:0.1.1 \
+    newrelic:1.0.1 \
     null:1.0.0 \
     pagerduty:1.1.0 \
     rabbitmq:0.2.0 \
@@ -100,7 +100,7 @@ LABEL terraform_version="${TERRAFORM_VERSION}"
 RUN mkdir -p /usr/local/bin && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
-    wget -q -O /etc/apk/keys/sgerrand.rsa.pub "https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub" && \
+    wget -q -O /etc/apk/keys/sgerrand.rsa.pub "https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub" && \
     wget -q "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk" && \
     apk update && \
     apk add glibc-2.23-r3.apk && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,6 @@ RUN mkdir -p /usr/local/bin/terraform-providers && \
     for provider in \
     aws:0.1.4 \
     aws:1.10.0 \
-    aws:1.18.0 \
     aws:1.33.0 \
     consul:0.1.0 \
     datadog:0.1.1 \


### PR DESCRIPTION
This is just first update.  I'll add the glibc updates as well.

But didn't know if we wanted to keep adding new versions of aws providers.  We have several now.  version 1.18.0 was added recently and used in 5 locations.  I'm wondering if I should replace those with latest, or just keep adding new versions for just stacks affected.