### PR TITLE
devops-1894: Update newrelic provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN mkdir -p /usr/local/bin/terraform-providers && \
     google:0.1.3 \
     heroku:0.1.0 \
     logentries:0.1.0 \
-    newrelic:1.0.1 \
+    newrelic:1.2.0 \
     null:1.0.0 \
     pagerduty:1.1.0 \
     rabbitmq:0.2.0 \


### PR DESCRIPTION
Need new provider for newrelic to add infrastructure alerts.  Need 1.1.0, but went to latest version.