### PR TITLE
Install Covalence from Fork Use Alpine container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,15 @@ jobs:
 
     environment:
       CI_IMAGE_NAME: 'whistle/ci'
-      PACKER_VERSION: 1.1.0
-      TERRAFORM_VERSION: 0.12.6
-
+      PACKER_VERSION: '1.1.0'
+      TERRAFORM_VERSION: '0.12.6'
+      ALPINE_VERSION: '3.10'
+      COVALENCE_VERSION: '0.9.7'
+      DUMBINIT_VERSION: '1.2.2'
+      GOSU_VERSION: '1.11'
+      RUBY_VERSION: '2.5.5'
+      SOPS_VERSION: '3.3.1'
+      BUNDLER_VERSION: '1.17.3'
     steps:
       - restore_cache:
           keys:
@@ -68,9 +74,16 @@ jobs:
               cmd=(
                 docker build
                 --rm=false
-
-                --build-arg "TERRAFORM_VERSION=${TERRAFORM_VERSION}"
-                --build-arg "PACKER_VERSION=${PACKER_VERSION}"
+                --build-arg CI_IMAGE_NAME
+                --build-arg PACKER_VERSION
+                --build-arg TERRAFORM_VERSION
+                --build-arg ALPINE_VERSION
+                --build-arg COVALENCE_VERSION
+                --build-arg DUMBINIT_VERSION
+                --build-arg GOSU_VERSION
+                --build-arg RUBY_VERSION
+                --build-arg SOPS_VERSION
+                --build-arg BUNDLER_VERSION
               )
 
               "${cmd[@]}" "$@"
@@ -78,6 +91,7 @@ jobs:
 
             # This is a multi-stage build, which means we need to cache both stages.
             build -t "$build_tag-build" --target build .
+            build -t "$build_tag-covbuild" --target covbuild .
             build -t "$build_tag" .
 
       - run:
@@ -98,7 +112,7 @@ jobs:
 
             # The history is also required to get each individual layer.
             # This is a multi-stage build, which means we need to cache both stages.
-            image_ids=($(get-image-ids "$build_tag" "$build_tag-build"))
+            image_ids=($(get-image-ids "$build_tag" "$build_tag-build" "$build_tag-covbuild"))
             docker save "$build_tag" "${image_ids[@]}" > ~/docker/image.tar
 
       - save_cache:
@@ -113,7 +127,7 @@ jobs:
 
             build_tag="${CI_IMAGE_NAME}:build"
 
-            docker run --entrypoint /bin/sh "$build_tag" -c "gem list | grep covalence"
+            docker run --entrypoint /bin/sh "$build_tag" -c "bundle info covalence"
             docker run --entrypoint /bin/sh "$build_tag" -c "aws --version"
 
             docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh "${build_tag}" -c "packer version"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # TODO - all security checking of downloaded binaries has been removed
+ARG ALPINE_VERSION
+ARG RUBY_VERSION
 
 FROM alpine:3.7 as build
-MAINTAINER "WhistleLabs, Inc. <devops@whistle.com>"
+LABEL maintainer="WhistleLabs, Inc. <devops@whistle.com>"
 
 RUN set -exv \
  && apk add --no-cache --update \
@@ -56,38 +58,125 @@ RUN set -exv \
     terraform-provider-sentry:0.4.0-whistle1-tf012 \
  && :
 
-FROM unifio/covalence:0.8.3
-MAINTAINER "WhistleLabs, Inc. <devops@whistle.com>"
+FROM ruby:${RUBY_VERSION}-alpine${ALPINE_VERSION} as covbuild
+ARG COVALENCE_VERSION
+ARG DUMBINIT_VERSION
+ARG GOSU_VERSION
+ARG GOSU_KEY
+ARG SOPS_VERSION
+ARG PREFIXOUT_VERSION
 
-RUN set -exv \
- && apk add --no-cache --update \
-        ca-certificates curl unzip zsh \
-        fzf \
- && :
-ENV SHELL=zsh
+ENV COVALENCE_VERSION $COVALENCE_VERSION
+ENV DUMBINIT_VERSION $DUMBINIT_VERSION
+ENV GOSU_VERSION $GOSU_VERSION
+ENV GOSU_KEY B42F6819007F00F88E364FD4036A9C25BF357DD4
+ENV SOPS_VERSION $SOPS_VERSION
+ENV PREFIXOUT_VERSION $PREFIXOUT_VERSION
+
+RUN set -ex; \
+  \
+  fetchDeps=' \
+    build-base \
+    ca-certificates \
+    curl-dev \
+    gnupg \
+    openssl \
+    python-dev \
+    ruby-dev \
+    unzip \
+    wget \
+    git \
+  '; \
+  apk add --no-cache --update $fetchDeps && \
+  \
+  mkdir -p /tmp/build && \
+  cd /tmp/build && \
+  \
+  # Gosu
+  wget -O /tmp/build/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64"; \
+  wget -O /tmp/build/gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc"; \
+  \
+  ( gpg --keyserver ipv4.pool.sks-keyservers.net --receive-keys "$GOSU_KEY" \
+  || gpg --keyserver ha.pool.sks-keyservers.net --receive-keys "$GOSU_KEY" ); \
+  gpg --batch --verify gosu.asc gosu; \
+  chmod +x gosu; \
+  \
+  # Dumb-init
+  wget -O /tmp/build/dumb-init "https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64"; \
+  chmod +x dumb-init; \
+  \
+  # Sops
+  wget -O /tmp/build/sops "https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux"; \
+  chmod +x sops
+
+COPY tools/covalence/Gemfile /tmp/build
+COPY tools/covalence/.gemrc /tmp/build
+
+RUN set -ex; \
+  \
+  cd /tmp/build && \
+  \
+  # Ruby Gems
+  bundle install --path=/opt/gems --binstubs=/opt/bin --jobs=4 --retry=3
+
+FROM ruby:${RUBY_VERSION}-alpine${ALPINE_VERSION}
 
 LABEL packer_version="${PACKER_VERSION}"
 LABEL terraform_version="${TERRAFORM_VERSION}"
+LABEL maintainer="WhistleLabs, Inc. <devops@whistle.com>"
 
-# Install glibc, PIP, AWS CLI and Misc. Ruby tools
+ENV COVALENCE_VERSION $covalence_version
+ENV BUNDLE_GEMFILE /opt/Gemfile
+ENV BUNDLE_PATH /opt/gems
+ENV PATH /opt/bin:$PATH
+
+COPY --from=covbuild /tmp/build/gosu /usr/local/bin/
+COPY --from=covbuild /tmp/build/dumb-init /usr/local/bin/
+COPY --from=covbuild /tmp/build/sops /usr/local/bin/
+COPY --from=covbuild /tmp/build/Gemfile /opt/
+COPY --from=covbuild /tmp/build/Gemfile.lock /opt/
+COPY --from=covbuild /tmp/build/.gemrc /opt/
+COPY --from=covbuild /opt/gems /opt/gems
+COPY --from=covbuild /opt/bin /opt/bin
 # TODO - postgresql-client is hopefully temporary, see DEVOPS-1844
+RUN set -exv; \
+  \
+  fetchDeps=' \
+    ca-certificates \
+    curl \
+    unzip \
+    zsh \
+    fzf \
+    curl-dev \
+    jq \
+    python-dev \
+    python3-dev \
+    postgresql-client \
+  '; \
+  apk add --no-cache --update $fetchDeps && \
+  # pip
+  echo "**** install pip ****" && \
+  python3 -m ensurepip && \
+  rm -r /usr/lib/python*/ensurepip && \
+  pip3 install --no-cache --upgrade pip setuptools wheel && \
+  pip3 install --no-cache --upgrade --ignore-installed awscli
+
+ENV SHELL=zsh
+
 RUN mkdir -p /usr/local/bin && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
+    # Install glibc
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub "https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub" && \
-    wget -q "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk" && \
-    apk update && \
-    apk add glibc-2.23-r3.apk && \
+    wget -q "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk" && \
+    apk add glibc-2.29-r0.apk && \
     apk add postgresql-client && \
-    apk add --no-cache --update curl curl-dev jq python-dev && \
-    curl -O https://bootstrap.pypa.io/get-pip.py && \
-    python get-pip.py && \
-    pip install awscli && \
-    gem install awesome_print thor --no-document && \
-    cd /tmp && \
+    # Install gem packages
+    bundle check --gemfile=/opt/Gemfile --path=/opt/gems || bundle install --binstubs=/opt/bin --gemfile=/opt/Gemfile --path=/opt/gems --jobs=4 --retry=3 && \
+    \
+    # Cleanup
+    cd / && \
     rm -rf /tmp/build
-
-
 # Copy required binaries from previous build stages
 COPY --from=build /build/bin/* /usr/local/bin/
 
@@ -96,14 +185,8 @@ COPY --from=build /build/bin/* /usr/local/bin/
 COPY --from=build /build/terraform-providers/* /usr/local/bin/terraform-providers/linux_amd64/
 RUN chmod 777 /usr/local/bin/terraform-providers/linux_amd64
 
-# HACK We should likely just not base from the unifio image period
 COPY .build_ts .
-RUN set -exv \
- && cd /usr/local/bundle/gems \
- && rm -rf covalence-* \
- && git clone -b master \
-    https://github.com/whistlelabs/covalence.git covalence-0.8.3 \
- && :
+COPY tools/covalence/entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -151,7 +151,11 @@ RUN set -exv; \
     jq \
     python-dev \
     python3-dev \
+    git \
     postgresql-client \
+    gnupg \
+    openssl \
+    unzip \
   '; \
   apk add --no-cache --update $fetchDeps && \
   # pip

--- a/tools/covalence/.gemrc
+++ b/tools/covalence/.gemrc
@@ -1,0 +1,2 @@
+install: --no-rdoc --no-ri
+update:  --no-rdoc --no-ri

--- a/tools/covalence/Gemfile
+++ b/tools/covalence/Gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org' do
+  gem 'awesome_print'
+  gem 'thor'
+  gem 'ci_reporter_rspec'
+  gem 'consul_loader'
+  gem 'dotenv'
+  gem 'rspec'
+  gem 'rspec_junit_formatter'
+  gem 'serverspec'
+  # Pulling covalence directly from git repo. See DEVOPS-2421
+  gem 'covalence', git: 'https://github.com/whistlelabs/covalence'
+end

--- a/tools/covalence/entrypoint.sh
+++ b/tools/covalence/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+## Defaulting to root user (UID 0) to maintain backwards compatibility
+USER_ID=${LOCAL_USER_ID:-0}
+
+function installProviders()
+{
+  local tfHomeDir providerDir
+  tfHomeDir="${1}"
+  providerDir="${2}"
+  if [ -d "$providerDir" ]; then
+    [ "$DEBUG" == true ] && echo "Copying third party plugins from .terraform.d/plugins to ${tfHomeDir}/.terraform.d/plugins"
+    mkdir -p "${tfHomeDir}"/.terraform.d/plugins && \
+    cp -p "${providerDir}"/terraform-* "${tfHomeDir}"/.terraform.d/plugins/ && \
+    chmod -R a+rx "${tfHomeDir}"/.terraform.d
+  else
+    echo "$providerDir does not exist. No thirdparty providers installed."
+  fi
+}
+if [ "$TEST_MODE" == true ]; then
+  echo "Holding the container process for testing"
+  sleep 60
+fi
+if [ "$DEBUG" == true ] ; then
+  echo "Starting with UID: $USER_ID"
+fi
+if [ "$USER_ID" -ne "0" ]; then
+  adduser -s /bin/sh -D -u $USER_ID user
+  export HOME=/home/user
+  [ ! -z "$TF_TP_PROVIDER_DIR" ] && installProviders /home/user "${TF_TP_PROVIDER_DIR}"
+  exec /usr/local/bin/dumb-init /usr/local/bin/gosu user "$@"
+else
+[ ! -z "$TF_TP_PROVIDER_DIR" ] && installProviders "${HOME}" "${TF_TP_PROVIDER_DIR}"
+  exec /usr/local/bin/dumb-init "$@"
+fi


### PR DESCRIPTION
DEVOPS-2421

* Updated the dockerfile and circleci config for whistle/dockerfile-ci to build from the latest ruby-alpine as done in the unifio/dockerfile-ci.
* Installing Covalence from the master branch of the ['whistlelabs/covalence'](https://github.com/whistlelabs/covalence) using Bundler. **NOTE**: This has the side effect of not displaying the covalence gem using the `gem list` command. See [PR #128](https://github.com/WhistleLabs/tools/pull/128)
* Added tools directory to store Gemfile for specifying required gems to bundle install during build. Includes the installation of the covalence gem from github fork.
* Added other required files to tools directory since no longer sourcing from legacy covalence container.
* Left initial provider build phase and created new covbuild phase which was added to circleci caching.