### PR TITLE
Update packer and plugins for packer v1.4.4 **TEST on infrastructure and Review before MERGE**

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
 
     environment:
       CI_IMAGE_NAME: 'whistle/ci'
-      PACKER_VERSION: '1.1.0'
+      PACKER_VERSION: '1.4.4'
       TERRAFORM_VERSION: '0.12.9'
       ALPINE_VERSION: '3.10'
       DUMBINIT_VERSION: '1.2.2'

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,9 @@ RUN set -exv \
  && :
 # @lmars releases
 RUN set -exv \
- && export uri_template='https://github.com/lmars/${name}/releases/download/v${full_ver}/${name}-${ver}-${arch}.zip' \
+ && export uri_template='https://github.com/lmars/${name}/releases/download/${full_ver}/${name}-${ver}-${arch}.zip' \
  # packer plugins
- && install-zipped-bin ./bin \
+ && arch=linux-amd64 install-zipped-bin ./bin \
     packer-post-processor-vagrant-s3:1.4.0 \
  && :
 # @WhistleLabs github releases
@@ -50,7 +50,7 @@ RUN set -exv \
  # packer plugins
  && install-zipped-bin ./bin \
     packer-provisioner-serverspec:0.1.1-whistle0 \
-    prefixout:0.1.1 \
+    prefixout:0.1.0 \
  # terraform providers
  && install-zipped-bin ./terraform-providers \
     terraform-provider-cloudamqp:0.0.1-whistle0-tf012 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,15 +37,20 @@ RUN set -exv \
     terraform-provider-null:2.1.2 \
     terraform-provider-template:2.1.2 \
  && :
-
+# @lmars releases
+RUN set -exv \
+ && export uri_template='https://github.com/lmars/${name}/releases/download/v${full_ver}/${name}-${ver}-${arch}.zip' \
+ # packer plugins
+ && install-zipped-bin ./bin \
+    packer-post-processor-vagrant-s3:1.4.0 \
+ && :
 # @WhistleLabs github releases
 RUN set -exv \
  && export uri_template='https://github.com/WhistleLabs/${name}/releases/download/v${full_ver}/${name}_${ver}_${arch}.zip' \
  # packer plugins
  && install-zipped-bin ./bin \
-    packer-post-processor-vagrant-s3:0.0.1-whistle0 \
-    packer-provisioner-serverspec:0.0.1-whistle0 \
-    prefixout:0.1.0 \
+    packer-provisioner-serverspec:0.1.1-whistle0 \
+    prefixout:0.1.1 \
  # terraform providers
  && install-zipped-bin ./terraform-providers \
     terraform-provider-cloudamqp:0.0.1-whistle0-tf012 \


### PR DESCRIPTION
* Updated the packer version to the latest.
* Updated the vagrant s3 provider to use the one built externally in lmars repo.
* Updated post-processor to use binary built in with support for packer 1.4.4