### PR TITLE
Fetch covalence sha during builds to avoid stale caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
       PACKER_VERSION: '1.1.0'
       TERRAFORM_VERSION: '0.12.9'
       ALPINE_VERSION: '3.10'
-      COVALENCE_VERSION: '0.9.7'
       DUMBINIT_VERSION: '1.2.2'
       GOSU_VERSION: '1.11'
       RUBY_VERSION: '2.5.5'
@@ -69,7 +68,8 @@ jobs:
             set -eo pipefail
 
             build_tag="${CI_IMAGE_NAME}:build"
-
+            # DEVOPS-2520 Grab the latest short sha for covalence
+            COVALENCE_VERSION=$(wget -qO- https://api.github.com/repos/WhistleLabs/covalence/commits/HEAD | jq -r '.sha' |  cut -b -7)
             build() {
               cmd=(
                 docker build
@@ -78,14 +78,13 @@ jobs:
                 --build-arg PACKER_VERSION
                 --build-arg TERRAFORM_VERSION
                 --build-arg ALPINE_VERSION
-                --build-arg COVALENCE_VERSION
+                --build-arg COVALENCE_VERSION=$COVALENCE_VERSION
                 --build-arg DUMBINIT_VERSION
                 --build-arg GOSU_VERSION
                 --build-arg RUBY_VERSION
                 --build-arg SOPS_VERSION
                 --build-arg BUNDLER_VERSION
               )
-
               "${cmd[@]}" "$@"
             }
 
@@ -126,7 +125,9 @@ jobs:
             set -eo pipefail
 
             build_tag="${CI_IMAGE_NAME}:build"
-
+            # DEVOPS-2520 Get latest covalence head sha to verify it matches whats installed
+            COVALENCE_VERSION=$(wget -qO- https://api.github.com/repos/WhistleLabs/covalence/commits/HEAD | jq -r '.sha' |  cut -b -7)
+            echo "latest covalence sha is: $COVALENCE_VERSION"
             docker run --entrypoint /bin/sh "$build_tag" -c "bundle info covalence"
             docker run --entrypoint /bin/sh "$build_tag" -c "aws --version"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,15 +117,18 @@ RUN set -ex; \
   cd /tmp/build && \
   \
   # Ruby Gems
+  # DEVOPS-2520 Output Covalence SHA to prevent stale cache
+  echo "**** install bundles and covalence ${COVALENCE_VERSION} ****" && \
   bundle install --path=/opt/gems --binstubs=/opt/bin --jobs=4 --retry=3
 
 FROM ruby:${RUBY_VERSION}-alpine${ALPINE_VERSION}
+ARG COVALENCE_VERSION
 
 LABEL packer_version="${PACKER_VERSION}"
 LABEL terraform_version="${TERRAFORM_VERSION}"
 LABEL maintainer="WhistleLabs, Inc. <devops@whistle.com>"
 
-ENV COVALENCE_VERSION $covalence_version
+ENV COVALENCE_VERSION $COVALENCE_VERSION
 ENV BUNDLE_GEMFILE /opt/Gemfile
 ENV BUNDLE_PATH /opt/gems
 ENV PATH /opt/bin:$PATH
@@ -175,7 +178,8 @@ RUN mkdir -p /usr/local/bin && \
     wget -q "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk" && \
     apk add glibc-2.29-r0.apk && \
     apk add postgresql-client && \
-    # Install gem packages
+    # Install gem packages and covalence if not already present
+    echo "**** install bundles and covalence ${COVALENCE_VERSION} ****" && \
     bundle check --gemfile=/opt/Gemfile --path=/opt/gems || bundle install --binstubs=/opt/bin --gemfile=/opt/Gemfile --path=/opt/gems --jobs=4 --retry=3 && \
     \
     # Cleanup


### PR DESCRIPTION
DEVOPS-2520
* Update unused COVALENCE_VERSION to use latest sha from github api request.
* Reference the COVALENCE_VERSION in docker build phases to avoid use of stale caches.