### PR TITLE
Update github provider to address drift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN set -exv \
  && install-zipped-bin ./terraform-providers \
     terraform-provider-archive:1.2.2 \
     terraform-provider-aws:2.44.0 \
-    terraform-provider-github:2.1.0 \
+    terraform-provider-github:2.3.1 \
     terraform-provider-google:2.7.0 \
     terraform-provider-newrelic:1.5.0 \
     terraform-provider-null:2.1.2 \


### PR DESCRIPTION
DEVOPS-2593
* Updated the github terraform provider to the latest in order to address drift due to API return change from github. See [issue #325](https://github.com/terraform-providers/terraform-provider-github/pull/325/commits)
**NOTE**: Tested this locally and saw that the latest provider addresses the drift as expected and the only drift seen is a recent manual deletion of matt bieber developer. 
![screenshot_4560](https://user-images.githubusercontent.com/15255373/73302774-074e6980-41ca-11ea-8509-17e0b2f14cbe.png)
