### PR TITLE
Updating terragrunt sops and build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,13 @@ jobs:
     environment:
       CI_IMAGE_NAME: 'whistle/ci'
       PACKER_VERSION: '1.4.4'
-      TERRAFORM_VERSION: '0.12.19'
+      TERRAFORM_VERSION: '0.12.29'
       ALPINE_VERSION: '3.10'
       DUMBINIT_VERSION: '1.2.2'
-      GOSU_VERSION: '1.11'
+      GOSU_VERSION: '1.12'
       RUBY_VERSION: '2.5.5'
-      SOPS_VERSION: '3.3.1'
-      TERRAGRUNT_VERSION: '0.23.24'
+      SOPS_VERSION: '3.6.1'
+      TERRAGRUNT_VERSION: '0.24.4'
       BUNDLER_VERSION: '1.17.3'
     steps:
       - restore_cache:
@@ -66,34 +66,7 @@ jobs:
       - run:
           name: Docker Build
           command: |
-            set -eo pipefail
-
-            build_tag="${CI_IMAGE_NAME}:build"
-            # DEVOPS-2520 Grab the latest short sha for covalence
-            COVALENCE_VERSION=$(wget -qO- https://api.github.com/repos/WhistleLabs/covalence/commits/HEAD | jq -r '.sha' |  cut -b -7)
-            build() {
-              cmd=(
-                docker build
-                --rm=false
-                --build-arg CI_IMAGE_NAME
-                --build-arg PACKER_VERSION
-                --build-arg TERRAFORM_VERSION
-                --build-arg ALPINE_VERSION
-                --build-arg COVALENCE_VERSION=$COVALENCE_VERSION
-                --build-arg DUMBINIT_VERSION
-                --build-arg GOSU_VERSION
-                --build-arg RUBY_VERSION
-                --build-arg SOPS_VERSION
-                --build-arg TERRAGRUNT_VERSION
-                --build-arg BUNDLER_VERSION
-              )
-              "${cmd[@]}" "$@"
-            }
-
-            # This is a multi-stage build, which means we need to cache both stages.
-            build -t "$build_tag-build" --target build .
-            build -t "$build_tag-covbuild" --target covbuild .
-            build -t "$build_tag" .
+            ./build-image
 
       - run:
           name: Save build
@@ -124,20 +97,7 @@ jobs:
       - run:
           name: Execute acceptance test
           command: |
-            set -eo pipefail
-
-            build_tag="${CI_IMAGE_NAME}:build"
-            # DEVOPS-2520 Get latest covalence head sha to verify it matches whats installed
-            COVALENCE_VERSION=$(wget -qO- https://api.github.com/repos/WhistleLabs/covalence/commits/HEAD | jq -r '.sha' |  cut -b -7)
-            echo "latest covalence sha is: $COVALENCE_VERSION"
-            docker run --entrypoint /bin/sh "$build_tag" -c "bundle info covalence"
-            docker run --entrypoint /bin/sh "$build_tag" -c "aws --version"
-
-            docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh "${build_tag}" -c "packer version"
-            docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh "${build_tag}" -c "terraform version"
-            docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh "${build_tag}" -c "terragrunt --version"
-            docker run --entrypoint /bin/sh "$build_tag" -c "lookup --version"
-
+            ./test-image
       - deploy:
           name: Register CI image
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,7 @@ RUN set -ex; \
   chmod +x dumb-init; \
   \
   # Sops
-  wget -O /tmp/build/sops "https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux"; \
+  wget -O /tmp/build/sops "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux"; \
   chmod +x sops; \
   \
   # terragrunt
@@ -227,4 +227,3 @@ COPY .build_ts .
 COPY tools/covalence/entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-

--- a/build-image
+++ b/build-image
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Required Variables
+CI_IMAGE_NAME=${CI_IMAGE_NAME:-whistle/ci}
+PACKER_VERSION=${PACKER_VERSION:-1.4.4}
+TERRAFORM_VERSION=${TERRAFORM_VERSION:-0.12.29}
+ALPINE_VERSION=${ALPINE_VERSION:-3.10}
+DUMBINIT_VERSION=${DUMBINIT_VERSION:-1.2.2}
+GOSU_VERSION=${GOSU_VERSION:-1.12}
+RUBY_VERSION=${RUBY_VERSION:-2.5.5}
+SOPS_VERSION=${SOPS_VERSION:-3.6.0}
+TERRAGRUNT_VERSION=${TERRAGRUNT_VERSION:-0.24.4}
+BUNDLER_VERSION=${BUNDLER_VERSION:-1.17.3}
+
+build_tag="${CI_IMAGE_NAME}:build"
+# DEVOPS-2520 Grab the latest short sha for covalence
+COVALENCE_VERSION=$(wget -qO- https://api.github.com/repos/WhistleLabs/covalence/commits/HEAD | jq -r '.sha' |  cut -b -7)
+
+build() {
+  cmd=(
+    docker build
+    --rm=false
+    --build-arg CI_IMAGE_NAME
+    --build-arg PACKER_VERSION
+    --build-arg TERRAFORM_VERSION
+    --build-arg ALPINE_VERSION
+    --build-arg COVALENCE_VERSION=$COVALENCE_VERSION
+    --build-arg DUMBINIT_VERSION
+    --build-arg GOSU_VERSION
+    --build-arg RUBY_VERSION
+    --build-arg SOPS_VERSION
+    --build-arg TERRAGRUNT_VERSION
+    --build-arg BUNDLER_VERSION
+  )
+  "${cmd[@]}" "$@"
+}
+
+# This is a multi-stage build, which means we need to cache both stages.
+build -t "$build_tag-build" --target build .
+build -t "$build_tag-covbuild" --target covbuild .
+build -t "$build_tag" .

--- a/test-image
+++ b/test-image
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eo pipefail
+# Required Variables
+CI_IMAGE_NAME=${CI_IMAGE_NAME:-whistle/ci}
+
+build_tag="${CI_IMAGE_NAME}:build"
+# DEVOPS-2520 Get latest covalence head sha to verify it matches whats installed
+COVALENCE_VERSION=$(wget -qO- https://api.github.com/repos/WhistleLabs/covalence/commits/HEAD | jq -r '.sha' |  cut -b -7)
+echo "latest covalence sha is: $COVALENCE_VERSION"
+docker run --entrypoint /bin/sh "$build_tag" -c "bundle info covalence"
+docker run --entrypoint /bin/sh "$build_tag" -c "aws --version"
+
+docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh "${build_tag}" -c "packer version"
+docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh "${build_tag}" -c "terraform version"
+docker run -e CHECKPOINT_DISABLE=1 --entrypoint /bin/sh "${build_tag}" -c "terragrunt --version"
+docker run --entrypoint /bin/sh "$build_tag" -c "lookup --version"
+docker run --entrypoint /bin/sh "${build_tag}" -c "sops --version"


### PR DESCRIPTION
DEVOPS-2706
* Updated terragrunt and sops versions
* Updated circleci to use a locally included build script to make building locally easier. Created build-image and test-image to handle this.
* Updated Dockerfile to handle new sops release uri format.
* Added output of sops version on image verification.