### PR TITLE
Adding bash for terragrunt script exctuables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN set -exv \
  # terraform providers
  && install-zipped-bin ./terraform-providers \
     terraform-provider-archive:1.2.2 \
-    terraform-provider-aws:2.44.0 \
+    terraform-provider-aws:2.70.0  \
     terraform-provider-github:2.3.1 \
     terraform-provider-google:2.7.0 \
     terraform-provider-kubernetes:1.11.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ LABEL maintainer="WhistleLabs, Inc. <devops@whistle.com>"
 
 RUN set -exv \
  && apk add --no-cache --update \
-        ca-certificates curl unzip zsh \
+        ca-certificates curl unzip bash zsh \
  && :
 
 WORKDIR /build


### PR DESCRIPTION
DEVOPS-2711
* Added bash to the dockerfile-ci script to allow execution of v3 terragrunt scripts.