### PR TITLE
Moved bash install to correct context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ LABEL maintainer="WhistleLabs, Inc. <devops@whistle.com>"
 
 RUN set -exv \
  && apk add --no-cache --update \
-        ca-certificates curl unzip bash zsh \
+        ca-certificates curl unzip zsh \
  && :
 
 WORKDIR /build
@@ -178,6 +178,7 @@ RUN set -exv; \
     curl \
     unzip \
     zsh \
+    bash \
     fzf \
     curl-dev \
     jq \


### PR DESCRIPTION
* Had installed bash for DEVOPS-2711 in the build container phase. Moved to the final container phase for final container. Bash is not needed in build container currently.