### PR TITLE
Remove nrs provider no longer used in any stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,6 @@ RUN set -exv \
     terraform-provider-datadog:1.9.0-whistle0-tf012 \
     terraform-provider-heroku:1.9.0-whistle0-tf012 \
     terraform-provider-logentries:1.0.0-whistle0-tf012 \
-    terraform-provider-nrs:0.1.0-whistle1-tf012 \
     terraform-provider-pagerduty:1.2.1-whistle0-tf012 \
     terraform-provider-rabbitmq:1.0.0-whistle0-tf012 \
  && :


### PR DESCRIPTION
DEVOPS-2869 DEVOPS-2884
* After removing nrs from all stack resources removing the nrs plugin from the docker container since it is no longer used.