### PR TITLE
[DEVOPS-3024][DEVOPS-2884]:fix: remove nrs provider update aws newrelic providers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,11 +54,11 @@ RUN set -exv \
  # terraform providers
  && install-zipped-bin ./terraform-providers \
     terraform-provider-archive:1.2.2 \
-    terraform-provider-aws:2.70.1  \
+    terraform-provider-aws:4.62.0  \
     terraform-provider-github:2.3.1 \
     terraform-provider-google:2.7.0 \
     terraform-provider-kubernetes:1.11.1 \
-    terraform-provider-newrelic:1.20.1 \
+    terraform-provider-newrelic:3.20.2 \
     terraform-provider-null:2.1.2 \
     terraform-provider-template:2.1.2 \
  && :

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,6 @@ RUN set -exv \
     terraform-provider-datadog:1.9.0-whistle0-tf012 \
     terraform-provider-heroku:1.9.0-whistle0-tf012 \
     terraform-provider-logentries:1.0.0-whistle0-tf012 \
-    terraform-provider-nrs:0.1.0-whistle1-tf012 \
     terraform-provider-pagerduty:1.2.1-whistle0-tf012 \
     terraform-provider-rabbitmq:1.0.0-whistle0-tf012 \
  && :


### PR DESCRIPTION
[fix: Updating providers to latest versions](https://github.com/WhistleLabs/dockerfile-ci/commit/57259b373ffb0eceb363649714034fd3861f8490)

* Updating AWS v4 provider to latest.
* Updating the newrelic provider to latest.

Jira: DEVOPS-3024

[Remove nrs provider no longer used in any stack](https://github.com/WhistleLabs/dockerfile-ci/commit/2cadc4d3dc8cf4e552e11a823159ee689577aa95)

DEVOPS-2869 DEVOPS-2884
* After removing nrs from all stack resources removing the nrs plugin from the docker container since it is no longer used.
