### PR TITLE
fix: Updating circleci docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
             - ".git"
 
       - setup_remote_docker:
-          version: 17.10.0-ce
+          version: default
 
       - run:
           name: docker info


### PR DESCRIPTION
* The circleci docker version that was being used is very old and was resulting in an error on sig key in this [build](https://app.circleci.com/pipelines/github/WhistleLabs/dockerfile-ci/51/workflows/975f5b58-f2d7-4d52-9ea9-406a1b97232d/jobs/326)
* Setting it to default latest version of docker which should work.